### PR TITLE
Remove descriptions before parsing

### DIFF
--- a/src/commands/load.yml
+++ b/src/commands/load.yml
@@ -6,7 +6,7 @@ parameters:
     type: string
     description: >
       One or more filters. Use a filter to return a more specific list of results. Ex: "Key=string,Option=string,Values=string,..."
-    default: ""
+    default: ''
 
 steps:
   - aws-cli/install
@@ -15,7 +15,7 @@ steps:
       name: Load AWS Parameters into environment
       command: |
         mkdir -p /tmp/parameterstore/
-        for row in $(aws ssm describe-parameters --no-paginate --parameter-filters << parameters.filter >> | jq -c '.Parameters[]'); do
+        for row in $(aws ssm describe-parameters --no-paginate --parameter-filters << parameters.filter >> | jq -c '.Parameters[]' | jq -c 'del(.Description)'); do
           _jq() {
             PARNAME=$(jq -r '.Name' \<<< "${row}")
             PARDATA=$(aws ssm get-parameters --with-decryption --names "${PARNAME}" | jq '.Parameters[].Value')


### PR DESCRIPTION
### Checklist

- [ x ] All new jobs, commands, executors, parameters have descriptions
- [ x ] Examples have been added for any significant new features
- [ x ] README has been updated, if necessary

### Motivation, issues

SSM Parameters with descriptions introduced newline characters into the for loop. Resulting in an exit code 4 as the JSON parsed on line 20 of `src/commans/load.yml` was invalid.

### Description

Added extra step to remove descriptions from returned parameter object before looping through values.

Closes #20